### PR TITLE
feat: add lasso and box triangle selection

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ const App = () => {
   const [gpsCoords, setGpsCoords] = useState(null);
 
   const [mode, setMode] = useState('view');
+  const [selectionMode, setSelectionMode] = useState(null);
   const [showSettings, setShowSettings] = useState(false);
   
   const [renderMode, setRenderMode] = useState('3dgs');
@@ -24,12 +25,23 @@ const App = () => {
     }
   }, [renderMode]);
 
+  const handleModeChange = (newMode) => {
+    setMode(newMode);
+    if (newMode === 'volume') {
+      setSelectionMode('lasso');
+    } else {
+      setSelectionMode(null);
+    }
+  };
+
   return (
     <>
       <StatsPanel />
       <FloatingToolbar
         currentMode={mode}
-        onModeChange={setMode}
+        selectionMode={selectionMode}
+        onModeChange={handleModeChange}
+        onSelectionModeChange={setSelectionMode}
         onToggleSettings={() => setShowSettings(prev => !prev)}
       />
       
@@ -49,6 +61,7 @@ const App = () => {
       <SceneModule
         renderMode={renderMode}
         currentMode={mode}
+        selectionMode={selectionMode}
         showBVH={showBVH}
         showCameraHelper={showCameraHelper}
         showWireframe={showWireframe}

--- a/src/components/CameraInfoPanel.jsx
+++ b/src/components/CameraInfoPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 const CameraInfoPanel = ({ colmap, ecef, gps }) => {
     return (

--- a/src/components/FloatingToolbar.jsx
+++ b/src/components/FloatingToolbar.jsx
@@ -3,8 +3,9 @@ import {
   LucideRuler,
   LucideCuboid,
   LucideEye,
-  LucideCamera,
   LucideSettings,
+  LucideLasso,
+  LucideSquare,
 } from 'lucide-react';
 
 const modes = [
@@ -13,9 +14,16 @@ const modes = [
   { id: 'volume', label: 'Volume', icon: <LucideCuboid size={18} /> },
 ];
 
+const selectionModes = [
+  { id: 'lasso', label: 'Lasso', icon: <LucideLasso size={18} /> },
+  { id: 'box', label: 'Box', icon: <LucideSquare size={18} /> },
+];
+
 const FloatingToolbar = ({
   currentMode,
+  selectionMode,
   onModeChange,
+  onSelectionModeChange,
   onToggleSettings
 }) => {
   return (
@@ -29,17 +37,31 @@ const FloatingToolbar = ({
             title={mode.label}
           >
             {mode.icon}
-          </button>
-        ))}
-        <hr className="toolbar-separator" />
-        <button
-          className="toolbar-btn"
-          onClick={onToggleSettings}
-          title="Settings"
-        >
-          <LucideSettings size={18} />
         </button>
+      ))}
+      <hr className="toolbar-separator" />
+      <button
+        className="toolbar-btn"
+        onClick={onToggleSettings}
+        title="Settings"
+      >
+        <LucideSettings size={18} />
+      </button>
       </div>
+      {currentMode === 'volume' && (
+        <div className="selection-toolbar">
+          {selectionModes.map((mode) => (
+            <button
+              key={mode.id}
+              className={`toolbar-btn ${selectionMode === mode.id ? 'active' : ''}`}
+              onClick={() => onSelectionModeChange(mode.id)}
+              title={mode.label}
+            >
+              {mode.icon}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ToggleColmapUI.jsx
+++ b/src/components/ToggleColmapUI.jsx
@@ -1,5 +1,5 @@
 // src/components/ToggleColmapUI.jsx
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 /**
  * Props:

--- a/src/components/WebviewerUI.jsx
+++ b/src/components/WebviewerUI.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 const WebViewerUI = ({
   currentMode,

--- a/src/scene/camera/ColmapCameraLoader.js
+++ b/src/scene/camera/ColmapCameraLoader.js
@@ -11,8 +11,7 @@ export async function loadColmapCameras(colmapPath, scene, cameraSwitcher) {
     offset += 8;
 
     for (let i = 0; i < numRegImages; i++) {
-        const imageId = dataView.getInt32(offset, true);
-        offset += 4;
+        offset += 4; // skip imageId
 
         const qvec = new THREE.Quaternion(
             dataView.getFloat64(offset + 8, true),
@@ -29,15 +28,12 @@ export async function loadColmapCameras(colmapPath, scene, cameraSwitcher) {
         );
         offset += 24;
 
-        const cameraId = dataView.getInt32(offset, true);
-        offset += 4;
+        offset += 4; // skip cameraId
         
-        let imageName = '';
         while (true) {
             const charCode = dataView.getInt8(offset);
-            offset ++;
+            offset++;
             if (charCode === 0) break;
-            imageName += String.fromCharCode(charCode);
         }
 
         const numPoints2D = Number(dataView.getBigUint64(offset, true));

--- a/src/scene/selection/BoxTool.js
+++ b/src/scene/selection/BoxTool.js
@@ -1,0 +1,148 @@
+import * as THREE from 'three';
+import { computeSelectedTriangles } from './computeSelectedTriangles.js';
+
+export class BoxTool {
+    constructor(scene, camera, domElement, overlayCanvas) {
+        this.scene = scene;
+        this.camera = camera;
+        this.domElement = domElement;
+        this.overlayCanvas = overlayCanvas;
+        this.ctx = overlayCanvas.getContext('2d');
+
+        this.isDrawing = false;
+        this.start = null;
+        this.end = null;
+        this.selectedMarkers = [];
+        this.mesh = null;
+        this.params = {
+            selectionMode: 'intersection',
+            selectWholeModel: false,
+            useBoundsTree: true,
+        };
+    }
+
+    setOverlayCanvas(canvas) {
+        this.overlayCanvas = canvas;
+        this.ctx = canvas.getContext('2d');
+    }
+
+    setMesh(mesh) {
+        this.mesh = mesh;
+    }
+
+    get points() {
+        if (!this.start || !this.end) return [];
+        const w = this.overlayCanvas.width;
+        const h = this.overlayCanvas.height;
+        const x1 = (this.start.x / w) * 2 - 1;
+        const y1 = -((this.start.y / h) * 2 - 1);
+        const x2 = (this.end.x / w) * 2 - 1;
+        const y2 = -((this.end.y / h) * 2 - 1);
+        return [
+            x1, y1, 0,
+            x2, y1, 0,
+            x2, y2, 0,
+            x1, y2, 0,
+        ];
+    }
+
+    activate() {
+        if (!this.domElement) return;
+        this._onMouseDown = this.onMouseDown.bind(this);
+        this._onMouseMove = this.onMouseMove.bind(this);
+        this._onMouseUp = this.onMouseUp.bind(this);
+        this.domElement.addEventListener('mousedown', this._onMouseDown);
+        this.domElement.addEventListener('mousemove', this._onMouseMove);
+        window.addEventListener('mouseup', this._onMouseUp);
+    }
+
+    deactivate() {
+        if (!this.domElement) return;
+        this.domElement.removeEventListener('mousedown', this._onMouseDown);
+        this.domElement.removeEventListener('mousemove', this._onMouseMove);
+        window.removeEventListener('mouseup', this._onMouseUp);
+        this.clearOverlay();
+        this.clearSelection();
+    }
+
+    onMouseDown(event) {
+        this.isDrawing = true;
+        const { clientX: x, clientY: y } = event;
+        this.start = { x, y };
+        this.end = { x, y };
+        this.clearOverlay();
+    }
+
+    onMouseMove(event) {
+        if (!this.isDrawing) return;
+        const { clientX: x, clientY: y } = event;
+        this.end = { x, y };
+        this.draw();
+    }
+
+    onMouseUp() {
+        if (!this.isDrawing) return;
+        this.isDrawing = false;
+        this.draw();
+        this.performSelection();
+    }
+
+    draw() {
+        if (!this.ctx || !this.start || !this.end) return;
+        const { x: x1, y: y1 } = this.start;
+        const { x: x2, y: y2 } = this.end;
+        const x = Math.min(x1, x2);
+        const y = Math.min(y1, y2);
+        const w = Math.abs(x2 - x1);
+        const h = Math.abs(y2 - y1);
+        this.ctx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+        this.ctx.strokeStyle = 'yellow';
+        this.ctx.lineWidth = 2;
+        this.ctx.strokeRect(x, y, w, h);
+    }
+
+    clearOverlay() {
+        if (this.ctx) {
+            this.ctx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+        }
+    }
+
+    clearSelection() {
+        this.selectedMarkers.forEach((m) => {
+            this.scene.remove(m);
+            m.geometry.dispose();
+            m.material.dispose();
+        });
+        this.selectedMarkers = [];
+    }
+
+    performSelection() {
+        if (!this.mesh || !this.camera || !this.start || !this.end) return;
+        const indices = computeSelectedTriangles(this.mesh, this.camera, this, this.params);
+        const positions = this.mesh.geometry.attributes.position;
+        const worldPosition = new THREE.Vector3();
+        const selected = [];
+        const unique = new Set(indices);
+        unique.forEach((i) => {
+            worldPosition.fromBufferAttribute(positions, i);
+            worldPosition.applyMatrix4(this.mesh.matrixWorld);
+            selected.push(worldPosition.clone());
+        });
+        this.highlight(selected);
+        console.log(`[BoxTool] Selected vertices: ${selected.length}`);
+    }
+
+    highlight(points) {
+        this.clearSelection();
+        const geometry = new THREE.SphereGeometry(0.01, 8, 8);
+        const material = new THREE.MeshBasicMaterial({ color: 0xffff00 });
+        points.forEach((p) => {
+            const marker = new THREE.Mesh(geometry, material.clone());
+            marker.position.copy(p);
+            marker.frustumCulled = false;
+            this.scene.add(marker);
+            this.selectedMarkers.push(marker);
+        });
+    }
+}
+

--- a/src/scene/selection/LassoTool.js
+++ b/src/scene/selection/LassoTool.js
@@ -1,0 +1,142 @@
+import * as THREE from 'three';
+import { computeSelectedTriangles } from './computeSelectedTriangles.js';
+
+export class LassoTool {
+    constructor(scene, camera, domElement, overlayCanvas) {
+        this.scene = scene;
+        this.camera = camera;
+        this.domElement = domElement;
+        this.overlayCanvas = overlayCanvas;
+        this.ctx = overlayCanvas.getContext('2d');
+
+        this.isDrawing = false;
+        this.path = [];
+        this.selectedMarkers = [];
+        this.mesh = null;
+        this.params = {
+            selectionMode: 'intersection',
+            selectWholeModel: false,
+            useBoundsTree: true,
+        };
+    }
+
+    setOverlayCanvas(canvas) {
+        this.overlayCanvas = canvas;
+        this.ctx = canvas.getContext('2d');
+    }
+
+    get points() {
+        const pts = [];
+        const w = this.overlayCanvas.width;
+        const h = this.overlayCanvas.height;
+        for (const p of this.path) {
+            const nx = (p.x / w) * 2 - 1;
+            const ny = -((p.y / h) * 2 - 1);
+            pts.push(nx, ny, 0);
+        }
+        return pts;
+    }
+
+    setMesh(mesh) {
+        this.mesh = mesh;
+    }
+
+    activate() {
+        if (!this.domElement) return;
+        this._onMouseDown = this.onMouseDown.bind(this);
+        this._onMouseMove = this.onMouseMove.bind(this);
+        this._onMouseUp = this.onMouseUp.bind(this);
+        this.domElement.addEventListener('mousedown', this._onMouseDown);
+        this.domElement.addEventListener('mousemove', this._onMouseMove);
+        window.addEventListener('mouseup', this._onMouseUp);
+    }
+
+    deactivate() {
+        if (!this.domElement) return;
+        this.domElement.removeEventListener('mousedown', this._onMouseDown);
+        this.domElement.removeEventListener('mousemove', this._onMouseMove);
+        window.removeEventListener('mouseup', this._onMouseUp);
+        this.clearOverlay();
+        this.clearSelection();
+    }
+
+    onMouseDown(event) {
+        this.isDrawing = true;
+        this.path = [{ x: event.clientX, y: event.clientY }];
+        this.clearOverlay();
+    }
+
+    onMouseMove(event) {
+        if (!this.isDrawing) return;
+        const { clientX: x, clientY: y } = event;
+        this.path.push({ x, y });
+        this.draw();
+    }
+
+    onMouseUp() {
+        if (!this.isDrawing) return;
+        this.isDrawing = false;
+        this.draw(true);
+        this.performSelection();
+    }
+
+    draw(close = false) {
+        if (!this.ctx) return;
+        this.ctx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+        if (this.path.length === 0) return;
+        this.ctx.strokeStyle = 'yellow';
+        this.ctx.lineWidth = 2;
+        this.ctx.beginPath();
+        this.ctx.moveTo(this.path[0].x, this.path[0].y);
+        for (let i = 1; i < this.path.length; i++) {
+            this.ctx.lineTo(this.path[i].x, this.path[i].y);
+        }
+        if (close) this.ctx.closePath();
+        this.ctx.stroke();
+    }
+
+    clearOverlay() {
+        if (this.ctx) {
+            this.ctx.clearRect(0, 0, this.overlayCanvas.width, this.overlayCanvas.height);
+        }
+    }
+
+    clearSelection() {
+        this.selectedMarkers.forEach((m) => {
+            this.scene.remove(m);
+            m.geometry.dispose();
+            m.material.dispose();
+        });
+        this.selectedMarkers = [];
+    }
+
+    performSelection() {
+        if (!this.mesh || !this.camera) return;
+        const indices = computeSelectedTriangles(this.mesh, this.camera, this, this.params);
+        const positions = this.mesh.geometry.attributes.position;
+        const worldPosition = new THREE.Vector3();
+        const selected = [];
+        const unique = new Set(indices);
+        unique.forEach((i) => {
+            worldPosition.fromBufferAttribute(positions, i);
+            worldPosition.applyMatrix4(this.mesh.matrixWorld);
+            selected.push(worldPosition.clone());
+        });
+        this.highlight(selected);
+        console.log(`[LassoTool] Selected vertices: ${selected.length}`);
+    }
+
+    highlight(points) {
+        this.clearSelection();
+        const geometry = new THREE.SphereGeometry(0.01, 8, 8);
+        const material = new THREE.MeshBasicMaterial({ color: 0xffff00 });
+        points.forEach((p) => {
+            const marker = new THREE.Mesh(geometry, material.clone());
+            marker.position.copy(p);
+            marker.frustumCulled = false;
+            this.scene.add(marker);
+            this.selectedMarkers.push(marker);
+        });
+    }
+}
+

--- a/src/scene/selection/computeSelectedTriangles.js
+++ b/src/scene/selection/computeSelectedTriangles.js
@@ -1,0 +1,209 @@
+import * as THREE from 'three';
+import { CONTAINED, INTERSECTED, NOT_INTERSECTED } from 'three-mesh-bvh';
+import { getConvexHull } from '../../utils/math/getConvexHull.js';
+import { lineCrossesLine } from '../../utils/math/lineCrossesLine.js';
+import { isPointInsidePolygon } from '../../utils/math/pointRayCrossesSegments.js';
+
+export function computeSelectedTriangles(mesh, camera, selectionTool, params) {
+    toScreenSpaceMatrix
+        .copy(mesh.matrixWorld)
+        .premultiply(camera.matrixWorldInverse)
+        .premultiply(camera.projectionMatrix);
+
+    invWorldMatrix.copy(mesh.matrixWorld).invert();
+    camLocalPosition
+        .set(0, 0, 0)
+        .applyMatrix4(camera.matrixWorld)
+        .applyMatrix4(invWorldMatrix);
+
+    const lassoSegments = connectPointsWithLines(
+        convertTripletsToPoints(selectionTool.points)
+    );
+
+    const perBoundsSegmentCache = [];
+    const indices = [];
+
+    mesh.geometry.boundsTree.shapecast({
+        intersectsBounds: (box, isLeaf, score, depth) => {
+            if (!params.useBoundsTree) {
+                return INTERSECTED;
+            }
+
+            const projectedBoxPoints = extractBoxVertices(box, boxPoints).map((v) =>
+                v.applyMatrix4(toScreenSpaceMatrix)
+            );
+
+            let minY = Infinity;
+            let maxY = -Infinity;
+            let minX = Infinity;
+            for (const point of projectedBoxPoints) {
+                if (point.y < minY) minY = point.y;
+                if (point.y > maxY) maxY = point.y;
+                if (point.x < minX) minX = point.x;
+            }
+
+            const parentSegments = perBoundsSegmentCache[depth - 1] || lassoSegments;
+            const segmentsToCheck = parentSegments.filter((segment) =>
+                isSegmentToTheRight(segment, minX, minY, maxY)
+            );
+            perBoundsSegmentCache[depth] = segmentsToCheck;
+
+            if (segmentsToCheck.length === 0) {
+                return NOT_INTERSECTED;
+            }
+
+            const hull = getConvexHull(projectedBoxPoints);
+            const hullSegments = connectPointsWithLines(hull, boxLines);
+
+            if (isPointInsidePolygon(segmentsToCheck[0].start, hullSegments)) {
+                return INTERSECTED;
+            }
+
+            for (const hullSegment of hullSegments) {
+                for (const selectionSegment of segmentsToCheck) {
+                    if (lineCrossesLine(hullSegment, selectionSegment)) {
+                        return INTERSECTED;
+                    }
+                }
+            }
+
+            return isPointInsidePolygon(hull[0], segmentsToCheck)
+                ? CONTAINED
+                : NOT_INTERSECTED;
+        },
+
+        intersectsTriangle: (tri, index, contained, depth) => {
+            const i3 = index * 3;
+            const a = i3 + 0;
+            const b = i3 + 1;
+            const c = i3 + 2;
+
+            const segmentsToCheck = params.useBoundsTree
+                ? perBoundsSegmentCache[depth]
+                : lassoSegments;
+            if (
+                params.selectionMode === 'centroid' ||
+                params.selectionMode === 'centroid-visible'
+            ) {
+                centroid.copy(tri.a).add(tri.b).add(tri.c).multiplyScalar(1 / 3);
+                screenCentroid.copy(centroid).applyMatrix4(toScreenSpaceMatrix);
+
+                if (
+                    contained ||
+                    isPointInsidePolygon(screenCentroid, segmentsToCheck)
+                ) {
+                    if (params.selectionMode === 'centroid-visible') {
+                        tri.getNormal(faceNormal);
+                        tempRay.origin.copy(centroid).addScaledVector(faceNormal, 1e-6);
+                        tempRay.direction.subVectors(camLocalPosition, centroid);
+
+                        const res = mesh.geometry.boundsTree.raycastFirst(
+                            tempRay,
+                            THREE.DoubleSide
+                        );
+                        if (res) {
+                            return false;
+                        }
+                    }
+
+                    indices.push(a, b, c);
+                    return params.selectWholeModel;
+                }
+            } else if (params.selectionMode === 'intersection') {
+                if (contained) {
+                    indices.push(a, b, c);
+                    return params.selectWholeModel;
+                }
+
+                const projectedTriangle = [tri.a, tri.b, tri.c].map((v) =>
+                    v.applyMatrix4(toScreenSpaceMatrix)
+                );
+                for (const point of projectedTriangle) {
+                    if (isPointInsidePolygon(point, segmentsToCheck)) {
+                        indices.push(a, b, c);
+                        return params.selectWholeModel;
+                    }
+                }
+
+                const triangleSegments = connectPointsWithLines(
+                    projectedTriangle,
+                    boxLines
+                );
+                for (const segment of triangleSegments) {
+                    for (const selectionSegment of segmentsToCheck) {
+                        if (lineCrossesLine(segment, selectionSegment)) {
+                            indices.push(a, b, c);
+                            return params.selectWholeModel;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        },
+    });
+
+    return indices;
+}
+
+const invWorldMatrix = new THREE.Matrix4();
+const camLocalPosition = new THREE.Vector3();
+const tempRay = new THREE.Ray();
+const centroid = new THREE.Vector3();
+const screenCentroid = new THREE.Vector3();
+const faceNormal = new THREE.Vector3();
+const toScreenSpaceMatrix = new THREE.Matrix4();
+const boxPoints = new Array(8).fill().map(() => new THREE.Vector3());
+const boxLines = new Array(12).fill().map(() => new THREE.Line3());
+
+function extractBoxVertices(box, target) {
+    const { min, max } = box;
+    let index = 0;
+    for (let x = 0; x <= 1; x++) {
+        for (let y = 0; y <= 1; y++) {
+            for (let z = 0; z <= 1; z++) {
+                const v = target[index];
+                v.x = x === 0 ? min.x : max.x;
+                v.y = y === 0 ? min.y : max.y;
+                v.z = z === 0 ? min.z : max.z;
+                index++;
+            }
+        }
+    }
+    return target;
+}
+
+function isSegmentToTheRight(segment, minX, minY, maxY) {
+    const sx = segment.start.x;
+    const sy = segment.start.y;
+    const ex = segment.end.x;
+    const ey = segment.end.y;
+
+    if (sx < minX && ex < minX) return false;
+    if (sy > maxY && ey > maxY) return false;
+    if (sy < minY && ey < minY) return false;
+
+    return true;
+}
+
+function connectPointsWithLines(points, target = null) {
+    if (target === null) {
+        target = new Array(points.length).fill(null).map(() => new THREE.Line3());
+    }
+
+    return points.map((p, i) => {
+        const nextP = points[(i + 1) % points.length];
+        const line = target[i];
+        line.start.copy(p);
+        line.end.copy(nextP);
+        return line;
+    });
+}
+
+function convertTripletsToPoints(array) {
+    const points = [];
+    for (let i = 0; i < array.length; i += 3) {
+        points.push(new THREE.Vector3(array[i], array[i + 1], array[i + 2]));
+    }
+    return points;
+}

--- a/src/styles/FloatingToolbar.css
+++ b/src/styles/FloatingToolbar.css
@@ -14,10 +14,30 @@
 }
 
 /* Floating toolbar */
+.floating-toolbar-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
 .floating-toolbar {
   position: absolute;
   top: 50%;
   left: 12px;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  background-color: #1e1e1e;
+  border-radius: 12px;
+  padding: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+}
+
+.selection-toolbar {
+  position: absolute;
+  top: 50%;
+  left: 70px;
   transform: translateY(-50%);
   display: flex;
   flex-direction: column;

--- a/src/utils/math/getConvexHull.js
+++ b/src/utils/math/getConvexHull.js
@@ -1,0 +1,25 @@
+export function getConvexHull(points) {
+    const pts = points.slice().sort((a, b) => (a.x === b.x ? a.y - b.y : a.x - b.x));
+    const cross = (o, a, b) => (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+
+    const lower = [];
+    for (const p of pts) {
+        while (lower.length >= 2 && cross(lower[lower.length - 2], lower[lower.length - 1], p) <= 0) {
+            lower.pop();
+        }
+        lower.push(p);
+    }
+
+    const upper = [];
+    for (let i = pts.length - 1; i >= 0; i--) {
+        const p = pts[i];
+        while (upper.length >= 2 && cross(upper[upper.length - 2], upper[upper.length - 1], p) <= 0) {
+            upper.pop();
+        }
+        upper.push(p);
+    }
+
+    upper.pop();
+    lower.pop();
+    return lower.concat(upper);
+}

--- a/src/utils/math/lineCrossesLine.js
+++ b/src/utils/math/lineCrossesLine.js
@@ -1,0 +1,15 @@
+
+export function lineCrossesLine(lineA, lineB) {
+    const a = lineA.start;
+    const b = lineA.end;
+    const c = lineB.start;
+    const d = lineB.end;
+
+    const denom = (d.y - c.y) * (b.x - a.x) - (d.x - c.x) * (b.y - a.y);
+    if (denom === 0) return false;
+
+    const ua = ((d.x - c.x) * (a.y - c.y) - (d.y - c.y) * (a.x - c.x)) / denom;
+    const ub = ((b.x - a.x) * (a.y - c.y) - (b.y - a.y) * (a.x - c.x)) / denom;
+
+    return ua >= 0 && ua <= 1 && ub >= 0 && ub <= 1;
+}

--- a/src/utils/math/pointRayCrossesSegments.js
+++ b/src/utils/math/pointRayCrossesSegments.js
@@ -1,0 +1,14 @@
+export function isPointInsidePolygon(point, segments) {
+    let count = 0;
+    const x = point.x;
+    const y = point.y;
+    for (const seg of segments) {
+        const x1 = seg.start.x;
+        const y1 = seg.start.y;
+        const x2 = seg.end.x;
+        const y2 = seg.end.y;
+        const intersects = (y1 > y) !== (y2 > y) && x < ((x2 - x1) * (y - y1)) / (y2 - y1) + x1;
+        if (intersects) count++;
+    }
+    return count % 2 === 1;
+}


### PR DESCRIPTION
## Summary
- integrate BVH-powered triangle selection helper
- wire lasso and box tools to compute normalized points and highlight selected vertices
- add geometric utilities for convex hulls, line intersection, and point-in-polygon tests

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68922d59ba008322a25cd7570eca1bf5